### PR TITLE
Switch on URLParams in explore and link from datasets

### DIFF
--- a/search/src/Components/dataset/dataset_list.js
+++ b/search/src/Components/dataset/dataset_list.js
@@ -10,6 +10,8 @@ import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 import Link from '@material-ui/core/Link';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import PhotoIcon from '@material-ui/icons/Photo';
+import IconButton from '@material-ui/core/IconButton';
 import axios from 'axios';
 
 
@@ -86,6 +88,7 @@ export default function DatasetList(props) {
               <TableCell className={classes.tableHeader}>Dataset Title</TableCell>
               {inReview ? <TableCell className={classes.tableHeader}>Contact</TableCell> : ""}
               <TableCell className={classes.tableHeader}>Upload Date</TableCell>
+              <TableCell className={classes.tableHeader}>Explore</TableCell>
               {inReview ? <TableCell className={classes.tableHeader}>Command</TableCell> : ""}
             </TableRow>
           </TableHead>
@@ -99,6 +102,7 @@ export default function DatasetList(props) {
                 </TableCell>
                 {inReview ? <TableCell><a href="mailto:{row.contributor_email}">{row.contributor_email}</a></TableCell> : ""}
                 <TableCell>{row.upload_date}</TableCell>
+                <TableCell><IconButton href={"/explore?dataset_name_filter=%5B%22" + row.name + "%22%5D"}><PhotoIcon /></IconButton></TableCell>
                 {inReview
                   ?<TableCell className={classes.commandCol}>
                     <button className={`${classes.command} ${classes.approval}`} onClick={() => handleApprove(row.upload_id)}>Approve</button>

--- a/search/src/Components/dataset/dataset_summary.js
+++ b/search/src/Components/dataset/dataset_summary.js
@@ -16,6 +16,8 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import axios from 'axios';
 import ListIcon from '@material-ui/icons/List';
+import PhotoIcon from '@material-ui/icons/Photo';
+import DownloadIcon from '@material-ui/icons/CloudDownload';
 import IconButton from '@material-ui/core/IconButton';
 import Cookies from 'js-cookie'
 import ReactMarkdown from "react-markdown";
@@ -40,12 +42,12 @@ const useStyles = (theme) => ({
   summary: {
   },
   download: {
-    padding: '1.5em 0',
-    width: '100%',
     fontSize: '1.2rem',
-    fontWeight: 900,
     backgroundColor: 'orange',
-    color: 'white',
+    color: 'black',
+    marginBottom: "1rem",
+    paddingTop: "1rem",
+    paddingBottom: "1rem",
   }
 });
 
@@ -185,12 +187,12 @@ export const DatasetSummary = (props) => {
                     </React.Fragment>
                 : []}
               </dl>
-              { /* TODO: link to Explore searching for just this dataset */ }
             </div>
           </Grid>
           <Grid item xs={2}>
             <div className={classes.summary}>
-                <Button className={classes.download} onClick={() => window.open(`${rootURL}/code/download/${upload_id}.zip`)}>Download in WeedCOCO format</Button>
+                <Button component="a" variant="contained" className={classes.download} startIcon={<DownloadIcon />} onClick={() => window.open(`${rootURL}/code/download/${upload_id}.zip`)}>Download in WeedCOCO format</Button>
+				<Button variant="outlined" startIcon={<PhotoIcon/>} href={"/explore?dataset_name_filter=%5B%22" + metadata.name + "%22%5D"}>Explore the Images</Button>
             </div>
           </Grid>
         </Grid>

--- a/search/src/Components/wrapper/reactive_search.js
+++ b/search/src/Components/wrapper/reactive_search.js
@@ -525,7 +525,7 @@ class ReactiveSearchComponent extends Component {
                     checkbox: "filter-checkbox"
                 },
                 queryFormat: "or",
-                URLParams: false,
+                URLParams: true,
                 react: {
                     and: [
                         "searchbox",
@@ -620,8 +620,9 @@ class ReactiveSearchComponent extends Component {
                     <MultiDropdownList
                         componentId="dataset_name_filter"
                         dataField="dataset_name.keyword"
-                        title="Datasets"
-                        placeholder="Select datasets"
+                        URLParams={true}
+                        title="Dataset Name"
+                        placeholder="Search datasets"
                         sortBy="asc"
                         filterLabel="Datasets"
                         {...makeProps("dataset_name_filter", true)}


### PR DESCRIPTION
Fixes #338


What this looks like on listing page:

![image](https://user-images.githubusercontent.com/78827/113055456-550f9900-91f6-11eb-98f6-2385c91efec3.png)

What this looks like on dataset summary page:

![image](https://user-images.githubusercontent.com/78827/113055503-65277880-91f6-11eb-8c9d-d47025af4edc.png)

On Explore page, each change of filters updates the URL.
TODO: Check whether we get range slider issues with URLParams=true when location slider (#360) is enabled
