### PR TITLE
Refactor step validation in upload_stepper

### DIFF
--- a/search/src/Components/forms/AgContextForm.js
+++ b/search/src/Components/forms/AgContextForm.js
@@ -137,7 +137,7 @@ class AgContextForm extends Component {
               ajv = {createAjv({useDefaults: true})}
               onChange={e => {
                   if (this.props.handleValidation){
-                    this.props.handleValidation('agcontexts', e.errors.length === 0);
+                    this.props.handleValidation(e.errors.length === 0);
                   }
                   this.setState({formData: e.data});
                   if (this.props.onChange) {

--- a/search/src/Components/forms/MetadataForm.js
+++ b/search/src/Components/forms/MetadataForm.js
@@ -108,7 +108,7 @@ class MetadataForm extends Component {
               ajv = {createAjv({useDefaults: true})}
               onChange={e => {
                   if (this.props.handleValidation){
-                    this.props.handleValidation('metadata', e.errors.length === 0);
+                    this.props.handleValidation(e.errors.length === 0);
                   }
                   this.setState({formData: e.data});
                   if (this.props.onChange) {

--- a/search/src/Components/upload/upload_stepper.js
+++ b/search/src/Components/upload/upload_stepper.js
@@ -58,11 +58,9 @@ class UploadStepper extends React.Component {
             upload_id: 0,
             images: [],
             categories: [],
-            imageReady: false,
+            stepValid: {},
             ag_context: {},
             metadata: {},
-            categories_saved: false,
-            coco_form_validation: {'agcontexts': false, 'metadata': false},
             error_message: "init",
             error_message_details: "",
         }
@@ -71,7 +69,6 @@ class UploadStepper extends React.Component {
         this.handleUploadId = this.handleUploadId.bind(this);
         this.handleImages = this.handleImages.bind(this);
         this.handleCategories = this.handleCategories.bind(this);
-        this.handleImageReady = this.handleImageReady.bind(this);
         this.handleUpdateCategories = this.handleUpdateCategories.bind(this);
         this.handleAgContextsFormData = this.handleAgContextsFormData.bind(this);
         this.handleMetadataFormData = this.handleMetadataFormData.bind(this);
@@ -83,9 +80,7 @@ class UploadStepper extends React.Component {
         this.handleUploadAgcontexts = this.handleUploadAgcontexts.bind(this);
         this.handleUploadMetadata = this.handleUploadMetadata.bind(this)
         this.handleSubmit = this.handleSubmit.bind(this);
-        this.handleCategoriesSaved = this.handleCategoriesSaved.bind(this);
         this.nextHandler = this.nextHandler.bind(this);
-        this.handleValidation = this.handleValidation.bind(this);
         this.getStepContent = this.getStepContent.bind(this);
     }
 
@@ -107,10 +102,6 @@ class UploadStepper extends React.Component {
 
     handleCategories(categories) {
         this.setState({categories: cloneDeep(categories)});
-    }
-
-    handleImageReady(imageReady) {
-        this.setState({imageReady: imageReady});
     }
 
     handleAgContextsFormData(formData) {
@@ -239,31 +230,25 @@ class UploadStepper extends React.Component {
         })
     }
 
-    handleValidation(formKey, status){
-        this.setState(prevState => {
-            const newState = {coco_form_validation: {...prevState.coco_form_validation}}
-            newState.coco_form_validation[formKey] = status
-            return newState
-        })
-    }
-
-    handleCategoriesSaved(categories_saved){
-        this.setState({categories_saved: categories_saved})
-    }
-
-    getStepContent() {
-        const step = stepsByType[this.props.upload_type][this.state.activeStep].type
+    getStepContent(step) {
+        const setValid = (status) => {
+            this.setState(prevState => {
+                const newState = {stepValid: {...prevState.stepValid}};
+                newState.stepValid[step] = status;
+                return newState;
+            })
+        }
         switch (step) {
             case "coco-upload":
             case "weedcoco-upload":
                 const schema = step == "coco-upload" ? "coco" : "weedcoco"
                 return <UploaderSingle upload_id={this.state.upload_id} images={this.state.images} handleUploadId={this.handleUploadId} handleImages={this.handleImages} handleCategories={this.handleCategories} handleErrorMessage={this.handleErrorMessage} schema={schema}/>
             case "categories":
-                return <CategoryMapper categories={cloneDeep(this.state.categories)} handleCategories={this.handleCategories} handleCategoriesSaved={this.handleCategoriesSaved} handleErrorMessage={this.handleErrorMessage}/>
+                return <CategoryMapper categories={cloneDeep(this.state.categories)} handleCategories={this.handleCategories} handleCategoriesSaved={setValid} handleErrorMessage={this.handleErrorMessage}/>
             case "agcontext":
                 return (
                     <React.Fragment>
-                        <AgContextForm formData={this.state.ag_context} handleValidation={this.handleValidation} onChange={e => {
+                        <AgContextForm formData={this.state.ag_context} handleValidation={setValid} onChange={e => {
                             this.handleAgContextsFormData(e.formData)
                             this.handleErrorMessage("init")
                         }} />
@@ -273,7 +258,7 @@ class UploadStepper extends React.Component {
             case "metadata":
                 return (
                     <React.Fragment>
-                        <MetadataForm formData={this.state.metadataFormData} handleValidation={this.handleValidation} onChange={e => {
+                        <MetadataForm formData={this.state.metadataFormData} handleValidation={setValid} onChange={e => {
                             this.handleMetadataFormData(e.formData)
                             this.handleErrorMessage("init")
                         }} />
@@ -281,36 +266,30 @@ class UploadStepper extends React.Component {
                     </React.Fragment>
                 )
             case "images":
-                return <UploaderImages upload_id={this.state.upload_id} images={this.state.images} handleImageReady={this.handleImageReady} handleErrorMessage={this.handleErrorMessage}/>
+                return <UploaderImages upload_id={this.state.upload_id} images={this.state.images} handleImageReady={setValid} handleErrorMessage={this.handleErrorMessage}/>
             default:
                 return ''
         }
     }
 
-    nextHandler() {
-        const step = stepsByType[this.props.upload_type][this.state.activeStep].type
-        const currentStageValid = (step) => {
-            switch (step) {
-                case "categories":
-                    return [this.state.categories_saved, this.handleUpdateCategories]
-                case "agcontext":
-                    return [this.state.coco_form_validation['agcontexts'], this.handleUploadAgcontexts]
-                case "metadata":
-                    return [this.state.coco_form_validation['metadata'], this.handleUploadMetadata]
-                case "images":
-                    return [this.state.imageReady, this.handleNext]
-                default:
-                    return [true, this.handleNext]
-            }
+    nextHandler(step) {
+        switch (step) {
+            case "categories":
+                return this.handleUpdateCategories
+            case "agcontext":
+                return this.handleUploadAgcontexts
+            case "metadata":
+                return this.handleUploadMetadata
+            case "images":
+                return this.handleNext
+            default:
+                return this.handleNext
         }
-        return {
-                nextValid: currentStageValid(step)[0] && this.state.error_message.length === 0,
-                nextHandler: currentStageValid(step)[1]
-               }
     }
 
     render(){
         const { classes } = this.props;
+        const stepName = stepsByType[this.props.upload_type][this.state.activeStep].type
         return (
             <div className={classes.root}>
             <Stepper activeStep={this.state.activeStep}>
@@ -332,7 +311,7 @@ class UploadStepper extends React.Component {
             </Stepper>
             <div>
                 <Typography className={classes.instructions}>
-                    {this.getStepContent()}
+                    {this.getStepContent(stepName)}
                 </Typography>
                 <ErrorMessage error={this.state.error_message} details={this.state.error_message_details}/>
                 <div>
@@ -355,9 +334,9 @@ class UploadStepper extends React.Component {
                     <Button
                         variant="contained"
                         color="primary"
-                        onClick={this.nextHandler().nextHandler}
+                        onClick={this.nextHandler(stepName)}
                         className={classes.button}
-                        disabled={!this.nextHandler().nextValid}
+                        disabled={!this.state.stepValid[stepName] || this.state.error_message.length !== 0}
                     >
                         {this.state.activeStep === this.state.steps.length - 1 ? 'Submit' : 'Next'}
                     </Button>


### PR DESCRIPTION
Hi @ElevnLi this is to demonstrate the reduction in redundant code when having a single state entry (an object keyed by step name) for step validation.

Note: untested