### PR TITLE
fixes spacing issue on category mapper uploader

### DIFF
--- a/search/src/Components/upload/uploader_category_mapper.js
+++ b/search/src/Components/upload/uploader_category_mapper.js
@@ -81,7 +81,7 @@ class CategoryMapper extends React.Component {
                             return (
                                 <li className={category.role && category.name ? classes.row : `${classes.row} ${classes.incomplete}`}>
                                     {/^[0-9A-Fa-f]{6}$/i.test(category.name) ? <div className={classes.color} style={{backgroundColor: '#' + category.name}}></div> : <p>{category.name}</p>}
-                                    <p className={classes.text_field}> is a</p>
+                                    <p className={classes.text_field}>&nbsp;&nbsp;is a</p>
                                     <FormControl className={classes.formControl}>
                                         <InputLabel id="category">Role</InputLabel>
                                         <Select


### PR DESCRIPTION
(hopefully) fixes the no space between `category name` and `is a` text in the category mapper uploader

![image](https://user-images.githubusercontent.com/51358498/131694656-75df50e1-4d58-464c-b57b-8990afa595ca.png)
