### PR TITLE
Loosen match of UNSPECIFIED in Cypress test

### DIFF
--- a/search/cypress/integration/weedai_upload.js
+++ b/search/cypress/integration/weedai_upload.js
@@ -25,7 +25,7 @@ describe('overall upload workflow', () => {
         cy.get('.dzu-input').attachFile('test_coco/coco.json')
         cy.clickText(/^Next$/)
         cy.findByText("crop").type('weed{enter}')
-        cy.findByDisplayValue(/^UNSPECIFIED$/).click().clear().type('rapistrum rugosum{enter}')
+        cy.findByDisplayValue(/UNSPECIFIED$/).click().clear().type('rapistrum rugosum{enter}')
         cy.clickText(/^Apply$/)
         cy.clickText(/^Next$/)
         cy.clickText(/^Upload and Download Form Contents$/)


### PR DESCRIPTION
Actual text on screen is 'weed: UNSPECIFIED' so it might not be matched by `^UNSPECIFIED$`